### PR TITLE
Adding object-fit on video element recipe

### DIFF
--- a/Recipe.min.js
+++ b/Recipe.min.js
@@ -1544,7 +1544,7 @@ void function() { try {
     RECIPE: object_fit_onvideo
     -------------------------------------------------------------
     Author: joevery
-    Description: All websites where object-fit CSS property is used on a video element.
+    Description: Get count of how many times object-fit CSS property is used on a video element on websites.
 */
 void function() {
     window.CSSUsage.StyleWalker.recipesToRun.push(
@@ -1556,8 +1556,9 @@ void function() {
             {
                 if (element.CSSUsage["object-fit"])
                 {
-                    results[nodeName] = results[nodeName] || { count: 0, };
-                    results[nodeName].count++;
+                    var key = "VIDEO" + "_" + "object-fit";
+                    results[key] = results[key] || { count: 0, };
+                    results[key].count++;
                 }
             }
             return results;

--- a/Recipe.min.js
+++ b/Recipe.min.js
@@ -1541,6 +1541,47 @@ void function() { try {
 } catch (ex) { /* do something maybe */ throw ex; } }();
 
 /* 
+    RECIPE: object_fit_object_position
+    -------------------------------------------------------------
+    Author: joevery
+    Description: Get count of how many times object-fit and object-position CSS properties are used on websites and classify by HTML tag.
+*/
+void function() {
+    window.CSSUsage.StyleWalker.recipesToRun.push(
+        function object_fit_object_position(element, results) 
+        {
+            // Need this to ensure no errors on html and head tags when running the code below.
+            if (!element.CSSUsage) return;
+
+            if (element.CSSUsage["object-fit"])
+            {
+                // Allows counting of number of HTML tags using object-fit CSS property on page.
+                results["object-fit"] = results["object-fit"] || { count: 0, };
+                results["object-fit"].count++;
+
+                // Classify count by HTML tag.
+                var nodeName = element.nodeName;
+                results["object-fit"][nodeName] = results["object-fit"][nodeName] || { count: 0, };
+                results["object-fit"][nodeName].count++;
+            }
+
+            if (element.CSSUsage["object-position"])
+            {
+                // Allows counting of number of HTML tags using object-position CSS property on page.
+                results["object-position"] = results["object-position"] || { count: 0, };
+                results["object-position"].count++;
+
+                // Classify count by HTML tag.
+                var nodeName = element.nodeName;
+                results["object-position"][nodeName] = results["object-position"][nodeName] || { count: 0, };
+                results["object-position"][nodeName].count++;
+            }
+
+            return results;
+        });
+}();
+
+/* 
     RECIPE: object_fit_onvideo
     -------------------------------------------------------------
     Author: joevery

--- a/Recipe.min.js
+++ b/Recipe.min.js
@@ -1607,6 +1607,49 @@ void function() {
 }();
 
 /* 
+    RECIPE: position-sticky_ancestry-tree
+    -------------------------------------------------------------
+    Author: joevery
+    Description: Get count of how many times position CSS property with value sticky are used on websites and classify by HTML tag.
+*/
+void function() {
+    window.CSSUsage.StyleWalker.recipesToRun.push(
+        function position_sticky_ancestry_tree(element, results) 
+        {
+            // Need this to ensure no errors on html and head tags when running the code below.
+            if (!element.CSSUsage) return;
+
+            if (element.CSSUsage["position"] == "sticky")
+            {
+                var nodeName = element.nodeName;
+
+                var ancestryTreeArray = [nodeName];
+
+                var currentParent = element.parentElement;
+
+                while (currentParent)
+                {
+                    ancestryTreeArray.push(currentParent.nodeName);
+                    currentParent = currentParent.parentElement;
+                }
+
+                var ancestryTree = ancestryTreeArray.join("-");
+
+                results["sticky"] = results["sticky"] || { count: 0, };
+                results["sticky"].count++;
+
+                results["sticky"][nodeName] = results["sticky"][nodeName] || { count: 0, };
+                results["sticky"][nodeName].count++;
+
+                results["sticky"][nodeName][ancestryTree] = results["sticky"][nodeName][ancestryTree] || { count: 0, };
+                results["sticky"][nodeName][ancestryTree].count++;
+            }
+
+            return results;
+        });
+}();
+
+/* 
     RECIPE: z-index on static flex items
     -------------------------------------------------------------
     Author: Francois Remy

--- a/Recipe.min.js
+++ b/Recipe.min.js
@@ -1541,6 +1541,30 @@ void function() { try {
 } catch (ex) { /* do something maybe */ throw ex; } }();
 
 /* 
+    RECIPE: object_fit_onvideo
+    -------------------------------------------------------------
+    Author: joevery
+    Description: All websites where object-fit CSS property is used on a video element.
+*/
+void function() {
+    window.CSSUsage.StyleWalker.recipesToRun.push(
+        function object_fit_onvideo(element, results) 
+        {
+            var nodeName = element.nodeName;
+
+            if (nodeName == "VIDEO")
+            {
+                if (element.CSSUsage["object-fit"])
+                {
+                    results[nodeName] = results[nodeName] || { count: 0, };
+                    results[nodeName].count++;
+                }
+            }
+            return results;
+        });
+}();
+
+/* 
     RECIPE: z-index on static flex items
     -------------------------------------------------------------
     Author: Francois Remy

--- a/cssUsage.src.js
+++ b/cssUsage.src.js
@@ -1544,7 +1544,7 @@ void function() { try {
     RECIPE: object_fit_onvideo
     -------------------------------------------------------------
     Author: joevery
-    Description: All websites where object-fit CSS property is used on a video element.
+    Description: Get count of how many times object-fit CSS property is used on a video element on websites.
 */
 void function() {
     window.CSSUsage.StyleWalker.recipesToRun.push(
@@ -1556,8 +1556,9 @@ void function() {
             {
                 if (element.CSSUsage["object-fit"])
                 {
-                    results[nodeName] = results[nodeName] || { count: 0, };
-                    results[nodeName].count++;
+                    var key = "VIDEO" + "_" + "object-fit";
+                    results[key] = results[key] || { count: 0, };
+                    results[key].count++;
                 }
             }
             return results;

--- a/cssUsage.src.js
+++ b/cssUsage.src.js
@@ -1541,6 +1541,47 @@ void function() { try {
 } catch (ex) { /* do something maybe */ throw ex; } }();
 
 /* 
+    RECIPE: object_fit_object_position
+    -------------------------------------------------------------
+    Author: joevery
+    Description: Get count of how many times object-fit and object-position CSS properties are used on websites and classify by HTML tag.
+*/
+void function() {
+    window.CSSUsage.StyleWalker.recipesToRun.push(
+        function object_fit_object_position(element, results) 
+        {
+            // Need this to ensure no errors on html and head tags when running the code below.
+            if (!element.CSSUsage) return;
+
+            if (element.CSSUsage["object-fit"])
+            {
+                // Allows counting of number of HTML tags using object-fit CSS property on page.
+                results["object-fit"] = results["object-fit"] || { count: 0, };
+                results["object-fit"].count++;
+
+                // Classify count by HTML tag.
+                var nodeName = element.nodeName;
+                results["object-fit"][nodeName] = results["object-fit"][nodeName] || { count: 0, };
+                results["object-fit"][nodeName].count++;
+            }
+
+            if (element.CSSUsage["object-position"])
+            {
+                // Allows counting of number of HTML tags using object-position CSS property on page.
+                results["object-position"] = results["object-position"] || { count: 0, };
+                results["object-position"].count++;
+
+                // Classify count by HTML tag.
+                var nodeName = element.nodeName;
+                results["object-position"][nodeName] = results["object-position"][nodeName] || { count: 0, };
+                results["object-position"][nodeName].count++;
+            }
+
+            return results;
+        });
+}();
+
+/* 
     RECIPE: object_fit_onvideo
     -------------------------------------------------------------
     Author: joevery

--- a/cssUsage.src.js
+++ b/cssUsage.src.js
@@ -1607,6 +1607,49 @@ void function() {
 }();
 
 /* 
+    RECIPE: position-sticky_ancestry-tree
+    -------------------------------------------------------------
+    Author: joevery
+    Description: Get count of how many times position CSS property with value sticky are used on websites and classify by HTML tag.
+*/
+void function() {
+    window.CSSUsage.StyleWalker.recipesToRun.push(
+        function position_sticky_ancestry_tree(element, results) 
+        {
+            // Need this to ensure no errors on html and head tags when running the code below.
+            if (!element.CSSUsage) return;
+
+            if (element.CSSUsage["position"] == "sticky")
+            {
+                var nodeName = element.nodeName;
+
+                var ancestryTreeArray = [nodeName];
+
+                var currentParent = element.parentElement;
+
+                while (currentParent)
+                {
+                    ancestryTreeArray.push(currentParent.nodeName);
+                    currentParent = currentParent.parentElement;
+                }
+
+                var ancestryTree = ancestryTreeArray.join("-");
+
+                results["sticky"] = results["sticky"] || { count: 0, };
+                results["sticky"].count++;
+
+                results["sticky"][nodeName] = results["sticky"][nodeName] || { count: 0, };
+                results["sticky"][nodeName].count++;
+
+                results["sticky"][nodeName][ancestryTree] = results["sticky"][nodeName][ancestryTree] || { count: 0, };
+                results["sticky"][nodeName][ancestryTree].count++;
+            }
+
+            return results;
+        });
+}();
+
+/* 
     RECIPE: z-index on static flex items
     -------------------------------------------------------------
     Author: Francois Remy

--- a/cssUsage.src.js
+++ b/cssUsage.src.js
@@ -1541,6 +1541,30 @@ void function() { try {
 } catch (ex) { /* do something maybe */ throw ex; } }();
 
 /* 
+    RECIPE: object_fit_onvideo
+    -------------------------------------------------------------
+    Author: joevery
+    Description: All websites where object-fit CSS property is used on a video element.
+*/
+void function() {
+    window.CSSUsage.StyleWalker.recipesToRun.push(
+        function object_fit_onvideo(element, results) 
+        {
+            var nodeName = element.nodeName;
+
+            if (nodeName == "VIDEO")
+            {
+                if (element.CSSUsage["object-fit"])
+                {
+                    results[nodeName] = results[nodeName] || { count: 0, };
+                    results[nodeName].count++;
+                }
+            }
+            return results;
+        });
+}();
+
+/* 
     RECIPE: z-index on static flex items
     -------------------------------------------------------------
     Author: Francois Remy

--- a/src/recipes/object-fit-onvideo.js
+++ b/src/recipes/object-fit-onvideo.js
@@ -1,0 +1,24 @@
+/* 
+    RECIPE: object_fit_onvideo
+    -------------------------------------------------------------
+    Author: joevery
+    Description: Get count of how many times object-fit CSS property is used on a video element on websites.
+*/
+void function() {
+    window.CSSUsage.StyleWalker.recipesToRun.push(
+        function object_fit_onvideo(element, results) 
+        {
+            var nodeName = element.nodeName;
+
+            if (nodeName == "VIDEO")
+            {
+                if (element.CSSUsage["object-fit"])
+                {
+                    var key = "VIDEO" + "_" + "object-fit";
+                    results[key] = results[key] || { count: 0, };
+                    results[key].count++;
+                }
+            }
+            return results;
+        });
+}();

--- a/src/recipes/object-fit_object-position.js
+++ b/src/recipes/object-fit_object-position.js
@@ -1,0 +1,40 @@
+/* 
+    RECIPE: object_fit_object_position
+    -------------------------------------------------------------
+    Author: joevery
+    Description: Get count of how many times object-fit and object-position CSS properties are used on websites and classify by HTML tag.
+*/
+void function() {
+    window.CSSUsage.StyleWalker.recipesToRun.push(
+        function object_fit_object_position(element, results) 
+        {
+            // Need this to ensure no errors on html and head tags when running the code below.
+            if (!element.CSSUsage) return;
+
+            if (element.CSSUsage["object-fit"])
+            {
+                // Allows counting of number of HTML tags using object-fit CSS property on page.
+                results["object-fit"] = results["object-fit"] || { count: 0, };
+                results["object-fit"].count++;
+
+                // Classify count by HTML tag.
+                var nodeName = element.nodeName;
+                results["object-fit"][nodeName] = results["object-fit"][nodeName] || { count: 0, };
+                results["object-fit"][nodeName].count++;
+            }
+
+            if (element.CSSUsage["object-position"])
+            {
+                // Allows counting of number of HTML tags using object-position CSS property on page.
+                results["object-position"] = results["object-position"] || { count: 0, };
+                results["object-position"].count++;
+
+                // Classify count by HTML tag.
+                var nodeName = element.nodeName;
+                results["object-position"][nodeName] = results["object-position"][nodeName] || { count: 0, };
+                results["object-position"][nodeName].count++;
+            }
+
+            return results;
+        });
+}();

--- a/src/recipes/position-sticky_ancestry-tree.js
+++ b/src/recipes/position-sticky_ancestry-tree.js
@@ -1,0 +1,42 @@
+/* 
+    RECIPE: position-sticky_ancestry-tree
+    -------------------------------------------------------------
+    Author: joevery
+    Description: Get count of how many times position CSS property with value sticky are used on websites and classify by HTML tag.
+*/
+void function() {
+    window.CSSUsage.StyleWalker.recipesToRun.push(
+        function position_sticky_ancestry_tree(element, results) 
+        {
+            // Need this to ensure no errors on html and head tags when running the code below.
+            if (!element.CSSUsage) return;
+
+            if (element.CSSUsage["position"] == "sticky")
+            {
+                var nodeName = element.nodeName;
+
+                var ancestryTreeArray = [nodeName];
+
+                var currentParent = element.parentElement;
+
+                while (currentParent)
+                {
+                    ancestryTreeArray.push(currentParent.nodeName);
+                    currentParent = currentParent.parentElement;
+                }
+
+                var ancestryTree = ancestryTreeArray.join("-");
+
+                results["sticky"] = results["sticky"] || { count: 0, };
+                results["sticky"].count++;
+
+                results["sticky"][nodeName] = results["sticky"][nodeName] || { count: 0, };
+                results["sticky"][nodeName].count++;
+
+                results["sticky"][nodeName][ancestryTree] = results["sticky"][nodeName][ancestryTree] || { count: 0, };
+                results["sticky"][nodeName][ancestryTree].count++;
+            }
+
+            return results;
+        });
+}();

--- a/tests/recipes/object-fit-onvideo.html
+++ b/tests/recipes/object-fit-onvideo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <title>Object fit on video element test</title>
+    <link type="text/css" href="../test-page/style.css" media="all" rel="stylesheet" />
+    <style>
+        .feature_wrapper {
+            border-style: solid;
+            display: inline-block;
+            margin-bottom: 15px;
+        }
+    </style>
+    <script src="../../Recipe.min.js"></script>
+</head>
+<body>
+    <div class="wrapper">
+        <h1>Object fit on video element test</h1>
+        <div id="nested-div">
+            <video id="videoTag1" src="" controls="controls" height="300" width="300" class="feature_wrapper" object-fit="fill"></video>
+        </div>
+    </div>
+</body>
+</html>

--- a/tests/recipes/object-fit-onvideo.html
+++ b/tests/recipes/object-fit-onvideo.html
@@ -8,6 +8,7 @@
             border-style: solid;
             display: inline-block;
             margin-bottom: 15px;
+            object-fit: fill;
         }
     </style>
     <script src="../../Recipe.min.js"></script>
@@ -16,7 +17,7 @@
     <div class="wrapper">
         <h1>Object fit on video element test</h1>
         <div id="nested-div">
-            <video id="videoTag1" src="" controls="controls" height="300" width="300" class="feature_wrapper" object-fit="fill"></video>
+            <video id="videoTag1" src="" controls="controls" height="300" width="300" class="feature_wrapper"></video>
         </div>
     </div>
 </body>

--- a/tests/recipes/object-fit_object-position.html
+++ b/tests/recipes/object-fit_object-position.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <title>Object fit and object position test</title>
+    <link type="text/css" href="../test-page/style.css" media="all" rel="stylesheet" />
+    <style>
+        .feature_wrapper {
+            border-style: solid;
+            display: inline-block;
+            margin-bottom: 15px;
+            object-fit: none;
+            object-position: top left;
+        }
+    </style>
+    <script src="../../Recipe.min.js"></script>
+</head>
+<body>
+    <div class="wrapper">
+        <h1>Object fit and object position test</h1>
+        <div id="nested-div1">
+            <video id="videoTag1" src="" controls="controls" height="300" width="300" class="feature_wrapper"></video>
+            <img id="imgTag1" height="300" width="300" class="feature_wrapper" />
+        </div>
+        <div id="nested-div2">
+            <video id="videoTag2" src="" controls="controls" height="300" width="300" style="object-fit:cover"></video>
+            <img id="imgTag2" height="300" width="300" style="object-position: bottom right" />
+        </div>
+        <div id="nested-div3">
+            <picture style="object-position: top right">
+                <img id="imgTag3" height="300" width="300" style="object-fit:contain" />
+            </picture>
+        </div>
+    </div>
+</body>
+</html>

--- a/tests/recipes/position-sticky_ancestry-tree.html
+++ b/tests/recipes/position-sticky_ancestry-tree.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <title>Position-sticky ancestry tree test</title>
+    <style>
+        div {
+            top: 10px;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        dl > div {
+            background: #FFF;
+            padding: 24px 0 0 0;
+        }
+
+        dt {
+            background: #B8C1C8;
+            border-bottom: 1px solid #989EA4;
+            border-top: 1px solid #717D85;
+            color: #FFF;
+            font: bold 18px/21px Helvetica, Arial, sans-serif;
+            margin: 0;
+            padding: 2px 0 0 12px;
+            position: sticky;
+            top: -1px;
+        }
+
+        dd {
+            font: bold 20px/45px Helvetica, Arial, sans-serif;
+            margin: 0;
+            padding: 0 0 0 12px;
+            white-space: nowrap;
+        }
+
+        dd + dd {
+            border-top: 1px solid #CCC;
+        }
+    </style>
+    <script src="../../Recipe.min.js"></script>
+</head>
+<body>
+    <dl>
+        <div>
+            <dt>A-sticky-label</dt>
+            <dd>Andrew W.K.</dd>
+            <dd>Apparat</dd>
+            <dd>Arcade Fire</dd>
+            <dd>At The Drive-In</dd>
+            <dd>Aziz Ansari</dd>
+            <dd>Andrew W.K.</dd>
+            <dd>Apparat</dd>
+            <dd>Arcade Fire</dd>
+            <dd>At The Drive-In</dd>
+            <dd>Aziz Ansari</dd>
+        </div>
+        <div>
+            <dt>C</dt>
+            <dd>Chromeo</dd>
+            <dd>Common</dd>
+            <dd>Converge</dd>
+            <dd>Crystal Castles</dd>
+            <dd>Cursive</dd>
+            <dd>Chromeo</dd>
+            <dd>Common</dd>
+            <dd>Converge</dd>
+            <dd>Crystal Castles</dd>
+            <dd>Cursive</dd>
+        </div>
+        <div>
+            <dt>E</dt>
+            <dd>Explosions In The Sky</dd>
+            <dd>Explosions In The Sky</dd>
+            <dd>Explosions In The Sky</dd>
+            <dd>Explosions In The Sky</dd>
+            <dd>Explosions In The Sky</dd>
+            <dd>Explosions In The Sky</dd>
+            <dd>Explosions In The Sky</dd>
+            <dd>Explosions In The Sky</dd>
+            <dd>Explosions In The Sky</dd>
+            <dd>Explosions In The Sky</dd>
+            <dd>Explosions In The Sky</dd>
+        </div>
+        <div>
+            <dt>T</dt>
+            <dd>Ted Leo &amp; The Pharmacists</dd>
+            <dd>T-Pain</dd>
+            <dd>Thrice</dd>
+            <dd>TV On The Radio</dd>
+            <dd>Two Gallants</dd>
+            <dd>Ted Leo &amp; The Pharmacists</dd>
+            <dd>T-Pain</dd>
+            <dd>Thrice</dd>
+            <dd>TV On The Radio</dd>
+            <dd>Two Gallants</dd>
+            <dd>Ted Leo &amp; The Pharmacists</dd>
+            <dd>T-Pain</dd>
+            <dd>Thrice</dd>
+            <dd>TV On The Radio</dd>
+            <dd>Two Gallants</dd>
+        </div>
+    </dl>
+</body>
+</html>


### PR DESCRIPTION
**Created simple recipe to count number of video elements with object-fit property on each web page run and test page with a video element with object-fit: fill property**

I still need to verify that the recipe works on the test page and I will work with @gregwhitworth on this, but we need these changes in asap to kick off crawler run for another team.

We plan to adapt this recipe to count all replaced elements that have the object-fit or object-position properties applied. 