### PR TITLE
Revised atrules collection 

### DIFF
--- a/Recipe.min.js
+++ b/Recipe.min.js
@@ -824,7 +824,6 @@ void function() { try {
 				atrulesUsage[selectorText] = Object.create(null);
 				atrulesUsage[selectorText] = {"count": 1, 
 											  "props": {},
-											  "nested": {},
 											  "conditions": {}} 
 			} else {
 				var count = atrulesUsage[selectorText].count;
@@ -835,64 +834,9 @@ void function() { try {
 
 			if(rule.cssRules) {
 				CSSUsage.PropertyValuesAnalyzer.anaylzeStyleOfRulePropCount(rule, selectedAtruleUsage);
-				processNestedRules(rule, selectedAtruleUsage.nested);
 			}
 
 			processConditionText(rule.conditionText, selectedAtruleUsage.conditions);
-		}
-
-		/**
-		 * Analyzes the given @atrules, such as @supports, and counts the usage of the nested rules
-		 * according to their type. NOTE: must pass in the current usage of nested rules for the
-		 * given @atrule.
-		 */
-		function processNestedRules(rule, nestedRulesUsage) {
-			// find the rule count for nested rules
-			for(let index in rule.cssRules) {
-				let ruleBody = rule.cssRules[index];
-
-				if(!ruleBody.cssText) {
-					continue;
-				}
-
-				var nestRuleSelector;
-
-				if(isRuleAnAtRule(ruleBody)) {
-					nestRuleSelector = '@atrule:' + ruleBody.type;
-
-				} else if(ruleBody.style) {
-					if(ruleBody.selectorText) {
-						try {
-							var selectorText = CSSUsage.PropertyValuesAnalyzer.cleanSelectorText(ruleBody.selectorText);
-							var matchedElements = [].slice.call(document.querySelectorAll(selectorText));
-
-							if(matchedElements.length == 0) {
-								continue;
-							}
-
-							var cleanedSelector = CSSUsage.PropertyValuesAnalyzer.generalizedSelectorsOf(selectorText);
-							nestRuleSelector = cleanedSelector[0];  // only passed in one selector to a function that returns many
-						} catch (ex) {
-							continue;
-						}
-					}
-				}
-
-				if(nestRuleSelector) {
-					var individualNested = nestRuleSelector.split(' ');
-
-					for (let selector of individualNested) {
-						if(!nestedRulesUsage[selector]) {
-							nestedRulesUsage[selector] = Object.create(null);
-							nestedRulesUsage[selector] = {"count": 1}
-						} else {
-							var nestedCount = nestedRulesUsage[selector].count;
-							nestedRulesUsage[selector].count = nestedCount + 1;
-						}
-					}
-				}
-			}
-
 		}
 
 		/**
@@ -1538,7 +1482,7 @@ void function() { try {
 						propsForSelectedAtrule[normalizedKey] = {"count": 1};
 					} else {
 						var propCount = propsForSelectedAtrule[normalizedKey].count;
-						propCount = propCount++;
+						propsForSelectedAtrule[normalizedKey].count = propCount + 1;
 					}
 				}
 			}

--- a/Recipe.min.js
+++ b/Recipe.min.js
@@ -935,12 +935,18 @@ void function() { try {
 				let keyframe = rule.cssRules[index];
 				var atrulesUsageForKeyframeOfSelector = atrulesUsageForSelector.keyframes;
 
-				if(keyframe.keyText) {
-					if(!atrulesUsageForKeyframeOfSelector[keyframe.keyText]) {
-						atrulesUsageForKeyframeOfSelector[keyframe.keyText] = {"count": 1};
+				if(!keyframe.keyText) {
+					continue;
+				}
+
+				var frames = keyframe.keyText.split(', ');
+
+				for (let frame of frames) {
+					if(!atrulesUsageForKeyframeOfSelector[frame]) {
+						atrulesUsageForKeyframeOfSelector[frame] = { "count" : 1 };
 					} else {
-						var keyframeCount = atrulesUsageForKeyframeOfSelector[keyframe.keyText].count;
-						atrulesUsageForKeyframeOfSelector[keyframe.keyText].count = keyframeCount + 1;
+						var keyframeCount = atrulesUsageForKeyframeOfSelector[frame].count;
+						atrulesUsageForKeyframeOfSelector[frame].count = keyframeCount + 1;
 					}
 				}
 			}
@@ -1455,6 +1461,20 @@ void function() { try {
 					continue;
 				}
 
+				if(ruleBody.selector) { 
+					try {
+						var selectorText = CssPropertyValuesAnalyzer.cleanSelectorText(ruleBody.selectorText);
+						var matchedElements = [].slice.call(document.querySelectorAll(selectorText));
+						
+						if (matchedElements.length == 0) {
+							continue;
+						}
+					} catch (ex) {
+						console.warn(ex.stack||("Invalid selector: "+selectorText+" -- via "+ruleBody.selectorText));
+						continue;
+					}
+				}	
+
 				let cssText = ' ' + style.cssText.toLowerCase(); 
 
 				for (var i = style.length; i--;) {
@@ -1781,6 +1801,8 @@ void function() { try {
 					delete cssUsageRules[key];
 				}
 			}
+
+			delete CSSUsageResults.atrules["@atrule:8"];  // delete duplicated data from atrule:7, keyframe
 		}
     }();
 	

--- a/Recipe.min.js
+++ b/Recipe.min.js
@@ -828,7 +828,7 @@ void function() { try {
 											  "conditions": {}} 
 			} else {
 				var count = atrulesUsage[selectorText].count;
-				count = count++;
+				atrulesUsage[selectorText].count = count + 1;
 			}
 
 			var selectedAtruleUsage = atrulesUsage[selectorText];
@@ -879,15 +879,20 @@ void function() { try {
 				}
 
 				if(nestRuleSelector) {
-					if(!nestedRulesUsage[nestRuleSelector]) {
-						nestedRulesUsage[nestRuleSelector] = Object.create(null);
-						nestedRulesUsage[nestRuleSelector] = {"count": 1}
-					} else {
-						var nestedCount = nestedRulesUsage[nestRuleSelector].count;
-						nestedCount = nestedCount++;
+					var individualNested = nestRuleSelector.split(' ');
+
+					for (let selector of individualNested) {
+						if(!nestedRulesUsage[selector]) {
+							nestedRulesUsage[selector] = Object.create(null);
+							nestedRulesUsage[selector] = {"count": 1}
+						} else {
+							var nestedCount = nestedRulesUsage[selector].count;
+							nestedRulesUsage[selector].count = nestedCount + 1;
+						}
 					}
 				}
 			}
+
 		}
 
 		/**
@@ -901,7 +906,7 @@ void function() { try {
 				selectedAtruleConditionalUsage[conditionText] = {"count": 1}
 			} else {
 				var count = selectedAtruleConditionalUsage[conditionText].count;
-				count = count++;
+				selectedAtruleConditionalUsage[conditionText].count = count + 1;
 			}
 		}
 
@@ -920,7 +925,7 @@ void function() { try {
 											  "props": {}} 
 			} else {
 				var count = atrulesUsage[selectorText].count;
-				count = count++;
+				atrulesUsage[selectorText].count = count + 1;
 			}
 
 			// @keyframes rule type is 7
@@ -957,7 +962,7 @@ void function() { try {
 				pseudosUsageForSelector[pseudoClass] = {"count": 1};
 			} else {
 				var pseudoCount = pseudosUsageForSelector[pseudoClass].count;
-				pseudoCount = pseudoCount++;
+				pseudosUsageForSelector[pseudoClass].count = pseudoCount + 1;
 			}
 		}
 
@@ -990,7 +995,7 @@ void function() { try {
 						atrulesUsageForKeyframeOfSelector[keyframe.keyText] = {"count": 1};
 					} else {
 						var keyframeCount = atrulesUsageForKeyframeOfSelector[keyframe.keyText].count;
-						keyframeCount = keyframeCount++;
+						atrulesUsageForKeyframeOfSelector[keyframe.keyText].count = keyframeCount + 1;
 					}
 				}
 			}
@@ -1813,6 +1818,7 @@ void function() { try {
 			CSSUsageResults.usages = results;
 			deleteDuplicatedAtRules(); // TODO: issue #52
 			
+			console.log(CSSUsageResults);
 			if(window.debugCSSUsage) if(window.debugCSSUsage) console.log(CSSUsageResults.usages);
 		}
 

--- a/Recipe.min.js
+++ b/Recipe.min.js
@@ -901,6 +901,7 @@ void function() { try {
 		 * of the @atrule in question.
 		 */
 		function processConditionText(conditionText, selectedAtruleConditionalUsage) {
+			conditionText = conditionText.replace(/[0-9]/g, '');
 			if(!selectedAtruleConditionalUsage[conditionText]) {
 				selectedAtruleConditionalUsage[conditionText] = Object.create(null);
 				selectedAtruleConditionalUsage[conditionText] = {"count": 1}

--- a/Recipe.min.js
+++ b/Recipe.min.js
@@ -847,7 +847,7 @@ void function() { try {
 		function processConditionText(conditionText, selectedAtruleConditionalUsage) {
 			// replace numeric specific information from condition statements
 			conditionText = conditionText.replace(/[0-9]+.*[0-9]+/g, '');
-			
+
 			if(!selectedAtruleConditionalUsage[conditionText]) {
 				selectedAtruleConditionalUsage[conditionText] = Object.create(null);
 				selectedAtruleConditionalUsage[conditionText] = {"count": 1}
@@ -1755,8 +1755,7 @@ void function() { try {
 			
 			CSSUsageResults.usages = results;
 			deleteDuplicatedAtRules(); // TODO: issue #52
-			
-			console.log(CSSUsageResults);
+
 			if(window.debugCSSUsage) if(window.debugCSSUsage) console.log(CSSUsageResults.usages);
 		}
 

--- a/Recipe.min.js
+++ b/Recipe.min.js
@@ -834,6 +834,7 @@ void function() { try {
 
 			if(rule.cssRules) {
 				CSSUsage.PropertyValuesAnalyzer.anaylzeStyleOfRulePropCount(rule, selectedAtruleUsage);
+				processNestedAtRules(rule.cssRules, selectedAtruleUsage);
 			}
 
 			processConditionText(rule.conditionText, selectedAtruleUsage.conditions);
@@ -846,12 +847,49 @@ void function() { try {
 		 */
 		function processConditionText(conditionText, selectedAtruleConditionalUsage) {
 			conditionText = conditionText.replace(/[0-9]/g, '');
+			conditionText = conditionText.replace(".px", "px");
+			conditionText = conditionText.replace(".em", "px");
 			if(!selectedAtruleConditionalUsage[conditionText]) {
 				selectedAtruleConditionalUsage[conditionText] = Object.create(null);
 				selectedAtruleConditionalUsage[conditionText] = {"count": 1}
 			} else {
 				var count = selectedAtruleConditionalUsage[conditionText].count;
 				selectedAtruleConditionalUsage[conditionText].count = count + 1;
+			}
+		}
+
+		/**
+		 * This processes the usage of nested atrules within other at rules.
+		 */
+		function processNestedAtRules(cssRules, selectedAtruleConditionalUsage) {
+			for(let index in cssRules) {
+				let ruleBody = cssRules[index];
+
+
+				if(!ruleBody.cssText) {
+					continue;
+				}
+
+				// only collect stats for sub atrules
+				if(!isRuleAnAtRule(ruleBody)) {
+					continue;
+				}
+
+				var nestRuleSelector = nestRuleSelector = '@atrule:' + ruleBody.type;
+
+				if(!selectedAtruleConditionalUsage["nested"]) {
+					selectedAtruleConditionalUsage["nested"] = Object.create(null);
+				}
+
+				var nestedUsage = selectedAtruleConditionalUsage["nested"];
+
+				if(!nestedUsage[nestRuleSelector]) {
+					nestedUsage[nestRuleSelector] = Object.create(null);
+					nestedUsage[nestRuleSelector] = { "count": 1 }
+				} else {
+					var nestedCount = nestedUsage[nestRuleSelector].count;
+					nestedUsage[nestRuleSelector].count = nestedCount + 1;
+				}
 			}
 		}
 
@@ -879,38 +917,7 @@ void function() { try {
 			} else if(CSSUsageResults.rules[selectorText].props) {
 				atrulesUsage[selectorText].props = CSSUsageResults.rules[selectorText].props;
 			}
-
-			if(rule.pseudoClass) {
-				processPseudoClassesOfAtrules(rule);
-			}
 		}
-
-
-		/**
-		 * If an atrule as has a pseudo class such as @page, process the pseudo class and
-		 * add it to the atrule usage.
-		 */
-		function processPseudoClassesOfAtrules(rule) {
-			var selectorText = '@atrule:' + rule.type;
-			var selectorAtruleUsage = CSSUsageResults.atrules[selectorText];
-
-			if(!selectorAtruleUsage["pseudos"]) {
-				selectorAtruleUsage["pseudos"] = Object.create(null);
-				selectorAtruleUsage["pseudos"] = {};
-			}
-
-			var pseudosUsageForSelector = selectorAtruleUsage["pseudos"];
-			let pseudoClass = rule.pseudoClass;
-
-			if(!pseudosUsageForSelector[pseudoClass]) {
-				pseudosUsageForSelector[pseudoClass] = Object.create(null);
-				pseudosUsageForSelector[pseudoClass] = {"count": 1};
-			} else {
-				var pseudoCount = pseudosUsageForSelector[pseudoClass].count;
-				pseudosUsageForSelector[pseudoClass].count = pseudoCount + 1;
-			}
-		}
-
 
 		/**
 		 * Processes on @keyframe to add the appropriate props from the frame and a counter of which

--- a/Recipe.min.js
+++ b/Recipe.min.js
@@ -834,7 +834,6 @@ void function() { try {
 
 			if(rule.cssRules) {
 				CSSUsage.PropertyValuesAnalyzer.anaylzeStyleOfRulePropCount(rule, selectedAtruleUsage);
-				processNestedAtRules(rule.cssRules, selectedAtruleUsage);
 			}
 
 			processConditionText(rule.conditionText, selectedAtruleUsage.conditions);
@@ -846,50 +845,15 @@ void function() { try {
 		 * of the @atrule in question.
 		 */
 		function processConditionText(conditionText, selectedAtruleConditionalUsage) {
-			conditionText = conditionText.replace(/[0-9]/g, '');
-			conditionText = conditionText.replace(".px", "px");
-			conditionText = conditionText.replace(".em", "px");
+			// replace numeric specific information from condition statements
+			conditionText = conditionText.replace(/[0-9]+.*[0-9]+/g, '');
+			
 			if(!selectedAtruleConditionalUsage[conditionText]) {
 				selectedAtruleConditionalUsage[conditionText] = Object.create(null);
 				selectedAtruleConditionalUsage[conditionText] = {"count": 1}
 			} else {
 				var count = selectedAtruleConditionalUsage[conditionText].count;
 				selectedAtruleConditionalUsage[conditionText].count = count + 1;
-			}
-		}
-
-		/**
-		 * This processes the usage of nested atrules within other at rules.
-		 */
-		function processNestedAtRules(cssRules, selectedAtruleConditionalUsage) {
-			for(let index in cssRules) {
-				let ruleBody = cssRules[index];
-
-
-				if(!ruleBody.cssText) {
-					continue;
-				}
-
-				// only collect stats for sub atrules
-				if(!isRuleAnAtRule(ruleBody)) {
-					continue;
-				}
-
-				var nestRuleSelector = nestRuleSelector = '@atrule:' + ruleBody.type;
-
-				if(!selectedAtruleConditionalUsage["nested"]) {
-					selectedAtruleConditionalUsage["nested"] = Object.create(null);
-				}
-
-				var nestedUsage = selectedAtruleConditionalUsage["nested"];
-
-				if(!nestedUsage[nestRuleSelector]) {
-					nestedUsage[nestRuleSelector] = Object.create(null);
-					nestedUsage[nestRuleSelector] = { "count": 1 }
-				} else {
-					var nestedCount = nestedUsage[nestRuleSelector].count;
-					nestedUsage[nestRuleSelector].count = nestedCount + 1;
-				}
 			}
 		}
 
@@ -916,6 +880,7 @@ void function() { try {
 				processKeyframeAtRules(rule);
 			} else if(CSSUsageResults.rules[selectorText].props) {
 				atrulesUsage[selectorText].props = CSSUsageResults.rules[selectorText].props;
+				delete atrulesUsage[selectorText].props.values;
 			}
 		}
 
@@ -937,6 +902,7 @@ void function() { try {
 			 * WARN: tightly coupled with previous processing of rules.
 			 */
 			atrulesUsageForSelector.props = CSSUsageResults.rules["@atrule:8"].props;
+			delete atrulesUsageForSelector.props.values;
 
 			for(let index in rule.cssRules) {
 				let keyframe = rule.cssRules[index];

--- a/cssUsage.src.js
+++ b/cssUsage.src.js
@@ -824,7 +824,6 @@ void function() { try {
 				atrulesUsage[selectorText] = Object.create(null);
 				atrulesUsage[selectorText] = {"count": 1, 
 											  "props": {},
-											  "nested": {},
 											  "conditions": {}} 
 			} else {
 				var count = atrulesUsage[selectorText].count;
@@ -835,64 +834,9 @@ void function() { try {
 
 			if(rule.cssRules) {
 				CSSUsage.PropertyValuesAnalyzer.anaylzeStyleOfRulePropCount(rule, selectedAtruleUsage);
-				processNestedRules(rule, selectedAtruleUsage.nested);
 			}
 
 			processConditionText(rule.conditionText, selectedAtruleUsage.conditions);
-		}
-
-		/**
-		 * Analyzes the given @atrules, such as @supports, and counts the usage of the nested rules
-		 * according to their type. NOTE: must pass in the current usage of nested rules for the
-		 * given @atrule.
-		 */
-		function processNestedRules(rule, nestedRulesUsage) {
-			// find the rule count for nested rules
-			for(let index in rule.cssRules) {
-				let ruleBody = rule.cssRules[index];
-
-				if(!ruleBody.cssText) {
-					continue;
-				}
-
-				var nestRuleSelector;
-
-				if(isRuleAnAtRule(ruleBody)) {
-					nestRuleSelector = '@atrule:' + ruleBody.type;
-
-				} else if(ruleBody.style) {
-					if(ruleBody.selectorText) {
-						try {
-							var selectorText = CSSUsage.PropertyValuesAnalyzer.cleanSelectorText(ruleBody.selectorText);
-							var matchedElements = [].slice.call(document.querySelectorAll(selectorText));
-
-							if(matchedElements.length == 0) {
-								continue;
-							}
-
-							var cleanedSelector = CSSUsage.PropertyValuesAnalyzer.generalizedSelectorsOf(selectorText);
-							nestRuleSelector = cleanedSelector[0];  // only passed in one selector to a function that returns many
-						} catch (ex) {
-							continue;
-						}
-					}
-				}
-
-				if(nestRuleSelector) {
-					var individualNested = nestRuleSelector.split(' ');
-
-					for (let selector of individualNested) {
-						if(!nestedRulesUsage[selector]) {
-							nestedRulesUsage[selector] = Object.create(null);
-							nestedRulesUsage[selector] = {"count": 1}
-						} else {
-							var nestedCount = nestedRulesUsage[selector].count;
-							nestedRulesUsage[selector].count = nestedCount + 1;
-						}
-					}
-				}
-			}
-
 		}
 
 		/**
@@ -1538,7 +1482,7 @@ void function() { try {
 						propsForSelectedAtrule[normalizedKey] = {"count": 1};
 					} else {
 						var propCount = propsForSelectedAtrule[normalizedKey].count;
-						propCount = propCount++;
+						propsForSelectedAtrule[normalizedKey].count = propCount + 1;
 					}
 				}
 			}

--- a/cssUsage.src.js
+++ b/cssUsage.src.js
@@ -935,12 +935,18 @@ void function() { try {
 				let keyframe = rule.cssRules[index];
 				var atrulesUsageForKeyframeOfSelector = atrulesUsageForSelector.keyframes;
 
-				if(keyframe.keyText) {
-					if(!atrulesUsageForKeyframeOfSelector[keyframe.keyText]) {
-						atrulesUsageForKeyframeOfSelector[keyframe.keyText] = {"count": 1};
+				if(!keyframe.keyText) {
+					continue;
+				}
+
+				var frames = keyframe.keyText.split(', ');
+
+				for (let frame of frames) {
+					if(!atrulesUsageForKeyframeOfSelector[frame]) {
+						atrulesUsageForKeyframeOfSelector[frame] = { "count" : 1 };
 					} else {
-						var keyframeCount = atrulesUsageForKeyframeOfSelector[keyframe.keyText].count;
-						atrulesUsageForKeyframeOfSelector[keyframe.keyText].count = keyframeCount + 1;
+						var keyframeCount = atrulesUsageForKeyframeOfSelector[frame].count;
+						atrulesUsageForKeyframeOfSelector[frame].count = keyframeCount + 1;
 					}
 				}
 			}
@@ -1455,6 +1461,20 @@ void function() { try {
 					continue;
 				}
 
+				if(ruleBody.selector) { 
+					try {
+						var selectorText = CssPropertyValuesAnalyzer.cleanSelectorText(ruleBody.selectorText);
+						var matchedElements = [].slice.call(document.querySelectorAll(selectorText));
+						
+						if (matchedElements.length == 0) {
+							continue;
+						}
+					} catch (ex) {
+						console.warn(ex.stack||("Invalid selector: "+selectorText+" -- via "+ruleBody.selectorText));
+						continue;
+					}
+				}	
+
 				let cssText = ' ' + style.cssText.toLowerCase(); 
 
 				for (var i = style.length; i--;) {
@@ -1781,6 +1801,8 @@ void function() { try {
 					delete cssUsageRules[key];
 				}
 			}
+
+			delete CSSUsageResults.atrules["@atrule:8"];  // delete duplicated data from atrule:7, keyframe
 		}
     }();
 	

--- a/cssUsage.src.js
+++ b/cssUsage.src.js
@@ -828,7 +828,7 @@ void function() { try {
 											  "conditions": {}} 
 			} else {
 				var count = atrulesUsage[selectorText].count;
-				count = count++;
+				atrulesUsage[selectorText].count = count + 1;
 			}
 
 			var selectedAtruleUsage = atrulesUsage[selectorText];
@@ -879,15 +879,20 @@ void function() { try {
 				}
 
 				if(nestRuleSelector) {
-					if(!nestedRulesUsage[nestRuleSelector]) {
-						nestedRulesUsage[nestRuleSelector] = Object.create(null);
-						nestedRulesUsage[nestRuleSelector] = {"count": 1}
-					} else {
-						var nestedCount = nestedRulesUsage[nestRuleSelector].count;
-						nestedCount = nestedCount++;
+					var individualNested = nestRuleSelector.split(' ');
+
+					for (let selector of individualNested) {
+						if(!nestedRulesUsage[selector]) {
+							nestedRulesUsage[selector] = Object.create(null);
+							nestedRulesUsage[selector] = {"count": 1}
+						} else {
+							var nestedCount = nestedRulesUsage[selector].count;
+							nestedRulesUsage[selector].count = nestedCount + 1;
+						}
 					}
 				}
 			}
+
 		}
 
 		/**
@@ -901,7 +906,7 @@ void function() { try {
 				selectedAtruleConditionalUsage[conditionText] = {"count": 1}
 			} else {
 				var count = selectedAtruleConditionalUsage[conditionText].count;
-				count = count++;
+				selectedAtruleConditionalUsage[conditionText].count = count + 1;
 			}
 		}
 
@@ -920,7 +925,7 @@ void function() { try {
 											  "props": {}} 
 			} else {
 				var count = atrulesUsage[selectorText].count;
-				count = count++;
+				atrulesUsage[selectorText].count = count + 1;
 			}
 
 			// @keyframes rule type is 7
@@ -957,7 +962,7 @@ void function() { try {
 				pseudosUsageForSelector[pseudoClass] = {"count": 1};
 			} else {
 				var pseudoCount = pseudosUsageForSelector[pseudoClass].count;
-				pseudoCount = pseudoCount++;
+				pseudosUsageForSelector[pseudoClass].count = pseudoCount + 1;
 			}
 		}
 
@@ -990,7 +995,7 @@ void function() { try {
 						atrulesUsageForKeyframeOfSelector[keyframe.keyText] = {"count": 1};
 					} else {
 						var keyframeCount = atrulesUsageForKeyframeOfSelector[keyframe.keyText].count;
-						keyframeCount = keyframeCount++;
+						atrulesUsageForKeyframeOfSelector[keyframe.keyText].count = keyframeCount + 1;
 					}
 				}
 			}
@@ -1813,6 +1818,7 @@ void function() { try {
 			CSSUsageResults.usages = results;
 			deleteDuplicatedAtRules(); // TODO: issue #52
 			
+			console.log(CSSUsageResults);
 			if(window.debugCSSUsage) if(window.debugCSSUsage) console.log(CSSUsageResults.usages);
 		}
 

--- a/cssUsage.src.js
+++ b/cssUsage.src.js
@@ -901,6 +901,7 @@ void function() { try {
 		 * of the @atrule in question.
 		 */
 		function processConditionText(conditionText, selectedAtruleConditionalUsage) {
+			conditionText = conditionText.replace(/[0-9]/g, '');
 			if(!selectedAtruleConditionalUsage[conditionText]) {
 				selectedAtruleConditionalUsage[conditionText] = Object.create(null);
 				selectedAtruleConditionalUsage[conditionText] = {"count": 1}

--- a/cssUsage.src.js
+++ b/cssUsage.src.js
@@ -847,7 +847,7 @@ void function() { try {
 		function processConditionText(conditionText, selectedAtruleConditionalUsage) {
 			// replace numeric specific information from condition statements
 			conditionText = conditionText.replace(/[0-9]+.*[0-9]+/g, '');
-			
+
 			if(!selectedAtruleConditionalUsage[conditionText]) {
 				selectedAtruleConditionalUsage[conditionText] = Object.create(null);
 				selectedAtruleConditionalUsage[conditionText] = {"count": 1}
@@ -1755,8 +1755,7 @@ void function() { try {
 			
 			CSSUsageResults.usages = results;
 			deleteDuplicatedAtRules(); // TODO: issue #52
-			
-			console.log(CSSUsageResults);
+
 			if(window.debugCSSUsage) if(window.debugCSSUsage) console.log(CSSUsageResults.usages);
 		}
 

--- a/cssUsage.src.js
+++ b/cssUsage.src.js
@@ -834,6 +834,7 @@ void function() { try {
 
 			if(rule.cssRules) {
 				CSSUsage.PropertyValuesAnalyzer.anaylzeStyleOfRulePropCount(rule, selectedAtruleUsage);
+				processNestedAtRules(rule.cssRules, selectedAtruleUsage);
 			}
 
 			processConditionText(rule.conditionText, selectedAtruleUsage.conditions);
@@ -846,12 +847,49 @@ void function() { try {
 		 */
 		function processConditionText(conditionText, selectedAtruleConditionalUsage) {
 			conditionText = conditionText.replace(/[0-9]/g, '');
+			conditionText = conditionText.replace(".px", "px");
+			conditionText = conditionText.replace(".em", "px");
 			if(!selectedAtruleConditionalUsage[conditionText]) {
 				selectedAtruleConditionalUsage[conditionText] = Object.create(null);
 				selectedAtruleConditionalUsage[conditionText] = {"count": 1}
 			} else {
 				var count = selectedAtruleConditionalUsage[conditionText].count;
 				selectedAtruleConditionalUsage[conditionText].count = count + 1;
+			}
+		}
+
+		/**
+		 * This processes the usage of nested atrules within other at rules.
+		 */
+		function processNestedAtRules(cssRules, selectedAtruleConditionalUsage) {
+			for(let index in cssRules) {
+				let ruleBody = cssRules[index];
+
+
+				if(!ruleBody.cssText) {
+					continue;
+				}
+
+				// only collect stats for sub atrules
+				if(!isRuleAnAtRule(ruleBody)) {
+					continue;
+				}
+
+				var nestRuleSelector = nestRuleSelector = '@atrule:' + ruleBody.type;
+
+				if(!selectedAtruleConditionalUsage["nested"]) {
+					selectedAtruleConditionalUsage["nested"] = Object.create(null);
+				}
+
+				var nestedUsage = selectedAtruleConditionalUsage["nested"];
+
+				if(!nestedUsage[nestRuleSelector]) {
+					nestedUsage[nestRuleSelector] = Object.create(null);
+					nestedUsage[nestRuleSelector] = { "count": 1 }
+				} else {
+					var nestedCount = nestedUsage[nestRuleSelector].count;
+					nestedUsage[nestRuleSelector].count = nestedCount + 1;
+				}
 			}
 		}
 
@@ -879,38 +917,7 @@ void function() { try {
 			} else if(CSSUsageResults.rules[selectorText].props) {
 				atrulesUsage[selectorText].props = CSSUsageResults.rules[selectorText].props;
 			}
-
-			if(rule.pseudoClass) {
-				processPseudoClassesOfAtrules(rule);
-			}
 		}
-
-
-		/**
-		 * If an atrule as has a pseudo class such as @page, process the pseudo class and
-		 * add it to the atrule usage.
-		 */
-		function processPseudoClassesOfAtrules(rule) {
-			var selectorText = '@atrule:' + rule.type;
-			var selectorAtruleUsage = CSSUsageResults.atrules[selectorText];
-
-			if(!selectorAtruleUsage["pseudos"]) {
-				selectorAtruleUsage["pseudos"] = Object.create(null);
-				selectorAtruleUsage["pseudos"] = {};
-			}
-
-			var pseudosUsageForSelector = selectorAtruleUsage["pseudos"];
-			let pseudoClass = rule.pseudoClass;
-
-			if(!pseudosUsageForSelector[pseudoClass]) {
-				pseudosUsageForSelector[pseudoClass] = Object.create(null);
-				pseudosUsageForSelector[pseudoClass] = {"count": 1};
-			} else {
-				var pseudoCount = pseudosUsageForSelector[pseudoClass].count;
-				pseudosUsageForSelector[pseudoClass].count = pseudoCount + 1;
-			}
-		}
-
 
 		/**
 		 * Processes on @keyframe to add the appropriate props from the frame and a counter of which

--- a/cssUsage.src.js
+++ b/cssUsage.src.js
@@ -834,7 +834,6 @@ void function() { try {
 
 			if(rule.cssRules) {
 				CSSUsage.PropertyValuesAnalyzer.anaylzeStyleOfRulePropCount(rule, selectedAtruleUsage);
-				processNestedAtRules(rule.cssRules, selectedAtruleUsage);
 			}
 
 			processConditionText(rule.conditionText, selectedAtruleUsage.conditions);
@@ -846,50 +845,15 @@ void function() { try {
 		 * of the @atrule in question.
 		 */
 		function processConditionText(conditionText, selectedAtruleConditionalUsage) {
-			conditionText = conditionText.replace(/[0-9]/g, '');
-			conditionText = conditionText.replace(".px", "px");
-			conditionText = conditionText.replace(".em", "px");
+			// replace numeric specific information from condition statements
+			conditionText = conditionText.replace(/[0-9]+.*[0-9]+/g, '');
+			
 			if(!selectedAtruleConditionalUsage[conditionText]) {
 				selectedAtruleConditionalUsage[conditionText] = Object.create(null);
 				selectedAtruleConditionalUsage[conditionText] = {"count": 1}
 			} else {
 				var count = selectedAtruleConditionalUsage[conditionText].count;
 				selectedAtruleConditionalUsage[conditionText].count = count + 1;
-			}
-		}
-
-		/**
-		 * This processes the usage of nested atrules within other at rules.
-		 */
-		function processNestedAtRules(cssRules, selectedAtruleConditionalUsage) {
-			for(let index in cssRules) {
-				let ruleBody = cssRules[index];
-
-
-				if(!ruleBody.cssText) {
-					continue;
-				}
-
-				// only collect stats for sub atrules
-				if(!isRuleAnAtRule(ruleBody)) {
-					continue;
-				}
-
-				var nestRuleSelector = nestRuleSelector = '@atrule:' + ruleBody.type;
-
-				if(!selectedAtruleConditionalUsage["nested"]) {
-					selectedAtruleConditionalUsage["nested"] = Object.create(null);
-				}
-
-				var nestedUsage = selectedAtruleConditionalUsage["nested"];
-
-				if(!nestedUsage[nestRuleSelector]) {
-					nestedUsage[nestRuleSelector] = Object.create(null);
-					nestedUsage[nestRuleSelector] = { "count": 1 }
-				} else {
-					var nestedCount = nestedUsage[nestRuleSelector].count;
-					nestedUsage[nestRuleSelector].count = nestedCount + 1;
-				}
 			}
 		}
 
@@ -916,6 +880,7 @@ void function() { try {
 				processKeyframeAtRules(rule);
 			} else if(CSSUsageResults.rules[selectorText].props) {
 				atrulesUsage[selectorText].props = CSSUsageResults.rules[selectorText].props;
+				delete atrulesUsage[selectorText].props.values;
 			}
 		}
 
@@ -937,6 +902,7 @@ void function() { try {
 			 * WARN: tightly coupled with previous processing of rules.
 			 */
 			atrulesUsageForSelector.props = CSSUsageResults.rules["@atrule:8"].props;
+			delete atrulesUsageForSelector.props.values;
 
 			for(let index in rule.cssRules) {
 				let keyframe = rule.cssRules[index];

--- a/src/cssUsage.js
+++ b/src/cssUsage.js
@@ -438,12 +438,18 @@ void function() { try {
 				let keyframe = rule.cssRules[index];
 				var atrulesUsageForKeyframeOfSelector = atrulesUsageForSelector.keyframes;
 
-				if(keyframe.keyText) {
-					if(!atrulesUsageForKeyframeOfSelector[keyframe.keyText]) {
-						atrulesUsageForKeyframeOfSelector[keyframe.keyText] = {"count": 1};
+				if(!keyframe.keyText) {
+					continue;
+				}
+
+				var frames = keyframe.keyText.split(', ');
+
+				for (let frame of frames) {
+					if(!atrulesUsageForKeyframeOfSelector[frame]) {
+						atrulesUsageForKeyframeOfSelector[frame] = { "count" : 1 };
 					} else {
-						var keyframeCount = atrulesUsageForKeyframeOfSelector[keyframe.keyText].count;
-						atrulesUsageForKeyframeOfSelector[keyframe.keyText].count = keyframeCount + 1;
+						var keyframeCount = atrulesUsageForKeyframeOfSelector[frame].count;
+						atrulesUsageForKeyframeOfSelector[frame].count = keyframeCount + 1;
 					}
 				}
 			}
@@ -958,6 +964,20 @@ void function() { try {
 					continue;
 				}
 
+				if(ruleBody.selector) { 
+					try {
+						var selectorText = CssPropertyValuesAnalyzer.cleanSelectorText(ruleBody.selectorText);
+						var matchedElements = [].slice.call(document.querySelectorAll(selectorText));
+						
+						if (matchedElements.length == 0) {
+							continue;
+						}
+					} catch (ex) {
+						console.warn(ex.stack||("Invalid selector: "+selectorText+" -- via "+ruleBody.selectorText));
+						continue;
+					}
+				}	
+
 				let cssText = ' ' + style.cssText.toLowerCase(); 
 
 				for (var i = style.length; i--;) {
@@ -1284,6 +1304,8 @@ void function() { try {
 					delete cssUsageRules[key];
 				}
 			}
+
+			delete CSSUsageResults.atrules["@atrule:8"];  // delete duplicated data from atrule:7, keyframe
 		}
     }();
 	

--- a/src/cssUsage.js
+++ b/src/cssUsage.js
@@ -404,6 +404,7 @@ void function() { try {
 		 * of the @atrule in question.
 		 */
 		function processConditionText(conditionText, selectedAtruleConditionalUsage) {
+			conditionText = conditionText.replace(/[0-9]/g, '');
 			if(!selectedAtruleConditionalUsage[conditionText]) {
 				selectedAtruleConditionalUsage[conditionText] = Object.create(null);
 				selectedAtruleConditionalUsage[conditionText] = {"count": 1}

--- a/src/cssUsage.js
+++ b/src/cssUsage.js
@@ -337,7 +337,6 @@ void function() { try {
 
 			if(rule.cssRules) {
 				CSSUsage.PropertyValuesAnalyzer.anaylzeStyleOfRulePropCount(rule, selectedAtruleUsage);
-				processNestedAtRules(rule.cssRules, selectedAtruleUsage);
 			}
 
 			processConditionText(rule.conditionText, selectedAtruleUsage.conditions);
@@ -349,50 +348,15 @@ void function() { try {
 		 * of the @atrule in question.
 		 */
 		function processConditionText(conditionText, selectedAtruleConditionalUsage) {
-			conditionText = conditionText.replace(/[0-9]/g, '');
-			conditionText = conditionText.replace(".px", "px");
-			conditionText = conditionText.replace(".em", "px");
+			// replace numeric specific information from condition statements
+			conditionText = conditionText.replace(/[0-9]+.*[0-9]+/g, '');
+			
 			if(!selectedAtruleConditionalUsage[conditionText]) {
 				selectedAtruleConditionalUsage[conditionText] = Object.create(null);
 				selectedAtruleConditionalUsage[conditionText] = {"count": 1}
 			} else {
 				var count = selectedAtruleConditionalUsage[conditionText].count;
 				selectedAtruleConditionalUsage[conditionText].count = count + 1;
-			}
-		}
-
-		/**
-		 * This processes the usage of nested atrules within other at rules.
-		 */
-		function processNestedAtRules(cssRules, selectedAtruleConditionalUsage) {
-			for(let index in cssRules) {
-				let ruleBody = cssRules[index];
-
-
-				if(!ruleBody.cssText) {
-					continue;
-				}
-
-				// only collect stats for sub atrules
-				if(!isRuleAnAtRule(ruleBody)) {
-					continue;
-				}
-
-				var nestRuleSelector = nestRuleSelector = '@atrule:' + ruleBody.type;
-
-				if(!selectedAtruleConditionalUsage["nested"]) {
-					selectedAtruleConditionalUsage["nested"] = Object.create(null);
-				}
-
-				var nestedUsage = selectedAtruleConditionalUsage["nested"];
-
-				if(!nestedUsage[nestRuleSelector]) {
-					nestedUsage[nestRuleSelector] = Object.create(null);
-					nestedUsage[nestRuleSelector] = { "count": 1 }
-				} else {
-					var nestedCount = nestedUsage[nestRuleSelector].count;
-					nestedUsage[nestRuleSelector].count = nestedCount + 1;
-				}
 			}
 		}
 
@@ -419,6 +383,7 @@ void function() { try {
 				processKeyframeAtRules(rule);
 			} else if(CSSUsageResults.rules[selectorText].props) {
 				atrulesUsage[selectorText].props = CSSUsageResults.rules[selectorText].props;
+				delete atrulesUsage[selectorText].props.values;
 			}
 		}
 
@@ -440,6 +405,7 @@ void function() { try {
 			 * WARN: tightly coupled with previous processing of rules.
 			 */
 			atrulesUsageForSelector.props = CSSUsageResults.rules["@atrule:8"].props;
+			delete atrulesUsageForSelector.props.values;
 
 			for(let index in rule.cssRules) {
 				let keyframe = rule.cssRules[index];

--- a/src/cssUsage.js
+++ b/src/cssUsage.js
@@ -350,7 +350,7 @@ void function() { try {
 		function processConditionText(conditionText, selectedAtruleConditionalUsage) {
 			// replace numeric specific information from condition statements
 			conditionText = conditionText.replace(/[0-9]+.*[0-9]+/g, '');
-			
+
 			if(!selectedAtruleConditionalUsage[conditionText]) {
 				selectedAtruleConditionalUsage[conditionText] = Object.create(null);
 				selectedAtruleConditionalUsage[conditionText] = {"count": 1}
@@ -1258,8 +1258,7 @@ void function() { try {
 			
 			CSSUsageResults.usages = results;
 			deleteDuplicatedAtRules(); // TODO: issue #52
-			
-			console.log(CSSUsageResults);
+
 			if(window.debugCSSUsage) if(window.debugCSSUsage) console.log(CSSUsageResults.usages);
 		}
 

--- a/src/cssUsage.js
+++ b/src/cssUsage.js
@@ -327,7 +327,6 @@ void function() { try {
 				atrulesUsage[selectorText] = Object.create(null);
 				atrulesUsage[selectorText] = {"count": 1, 
 											  "props": {},
-											  "nested": {},
 											  "conditions": {}} 
 			} else {
 				var count = atrulesUsage[selectorText].count;
@@ -338,64 +337,9 @@ void function() { try {
 
 			if(rule.cssRules) {
 				CSSUsage.PropertyValuesAnalyzer.anaylzeStyleOfRulePropCount(rule, selectedAtruleUsage);
-				processNestedRules(rule, selectedAtruleUsage.nested);
 			}
 
 			processConditionText(rule.conditionText, selectedAtruleUsage.conditions);
-		}
-
-		/**
-		 * Analyzes the given @atrules, such as @supports, and counts the usage of the nested rules
-		 * according to their type. NOTE: must pass in the current usage of nested rules for the
-		 * given @atrule.
-		 */
-		function processNestedRules(rule, nestedRulesUsage) {
-			// find the rule count for nested rules
-			for(let index in rule.cssRules) {
-				let ruleBody = rule.cssRules[index];
-
-				if(!ruleBody.cssText) {
-					continue;
-				}
-
-				var nestRuleSelector;
-
-				if(isRuleAnAtRule(ruleBody)) {
-					nestRuleSelector = '@atrule:' + ruleBody.type;
-
-				} else if(ruleBody.style) {
-					if(ruleBody.selectorText) {
-						try {
-							var selectorText = CSSUsage.PropertyValuesAnalyzer.cleanSelectorText(ruleBody.selectorText);
-							var matchedElements = [].slice.call(document.querySelectorAll(selectorText));
-
-							if(matchedElements.length == 0) {
-								continue;
-							}
-
-							var cleanedSelector = CSSUsage.PropertyValuesAnalyzer.generalizedSelectorsOf(selectorText);
-							nestRuleSelector = cleanedSelector[0];  // only passed in one selector to a function that returns many
-						} catch (ex) {
-							continue;
-						}
-					}
-				}
-
-				if(nestRuleSelector) {
-					var individualNested = nestRuleSelector.split(' ');
-
-					for (let selector of individualNested) {
-						if(!nestedRulesUsage[selector]) {
-							nestedRulesUsage[selector] = Object.create(null);
-							nestedRulesUsage[selector] = {"count": 1}
-						} else {
-							var nestedCount = nestedRulesUsage[selector].count;
-							nestedRulesUsage[selector].count = nestedCount + 1;
-						}
-					}
-				}
-			}
-
 		}
 
 		/**
@@ -1041,7 +985,7 @@ void function() { try {
 						propsForSelectedAtrule[normalizedKey] = {"count": 1};
 					} else {
 						var propCount = propsForSelectedAtrule[normalizedKey].count;
-						propCount = propCount++;
+						propsForSelectedAtrule[normalizedKey].count = propCount + 1;
 					}
 				}
 			}

--- a/src/cssUsage.js
+++ b/src/cssUsage.js
@@ -331,7 +331,7 @@ void function() { try {
 											  "conditions": {}} 
 			} else {
 				var count = atrulesUsage[selectorText].count;
-				count = count++;
+				atrulesUsage[selectorText].count = count + 1;
 			}
 
 			var selectedAtruleUsage = atrulesUsage[selectorText];
@@ -382,15 +382,20 @@ void function() { try {
 				}
 
 				if(nestRuleSelector) {
-					if(!nestedRulesUsage[nestRuleSelector]) {
-						nestedRulesUsage[nestRuleSelector] = Object.create(null);
-						nestedRulesUsage[nestRuleSelector] = {"count": 1}
-					} else {
-						var nestedCount = nestedRulesUsage[nestRuleSelector].count;
-						nestedCount = nestedCount++;
+					var individualNested = nestRuleSelector.split(' ');
+
+					for (let selector of individualNested) {
+						if(!nestedRulesUsage[selector]) {
+							nestedRulesUsage[selector] = Object.create(null);
+							nestedRulesUsage[selector] = {"count": 1}
+						} else {
+							var nestedCount = nestedRulesUsage[selector].count;
+							nestedRulesUsage[selector].count = nestedCount + 1;
+						}
 					}
 				}
 			}
+
 		}
 
 		/**
@@ -404,7 +409,7 @@ void function() { try {
 				selectedAtruleConditionalUsage[conditionText] = {"count": 1}
 			} else {
 				var count = selectedAtruleConditionalUsage[conditionText].count;
-				count = count++;
+				selectedAtruleConditionalUsage[conditionText].count = count + 1;
 			}
 		}
 
@@ -423,7 +428,7 @@ void function() { try {
 											  "props": {}} 
 			} else {
 				var count = atrulesUsage[selectorText].count;
-				count = count++;
+				atrulesUsage[selectorText].count = count + 1;
 			}
 
 			// @keyframes rule type is 7
@@ -460,7 +465,7 @@ void function() { try {
 				pseudosUsageForSelector[pseudoClass] = {"count": 1};
 			} else {
 				var pseudoCount = pseudosUsageForSelector[pseudoClass].count;
-				pseudoCount = pseudoCount++;
+				pseudosUsageForSelector[pseudoClass].count = pseudoCount + 1;
 			}
 		}
 
@@ -493,7 +498,7 @@ void function() { try {
 						atrulesUsageForKeyframeOfSelector[keyframe.keyText] = {"count": 1};
 					} else {
 						var keyframeCount = atrulesUsageForKeyframeOfSelector[keyframe.keyText].count;
-						keyframeCount = keyframeCount++;
+						atrulesUsageForKeyframeOfSelector[keyframe.keyText].count = keyframeCount + 1;
 					}
 				}
 			}
@@ -1316,6 +1321,7 @@ void function() { try {
 			CSSUsageResults.usages = results;
 			deleteDuplicatedAtRules(); // TODO: issue #52
 			
+			console.log(CSSUsageResults);
 			if(window.debugCSSUsage) if(window.debugCSSUsage) console.log(CSSUsageResults.usages);
 		}
 

--- a/tests/test-page-atrules/styles.css
+++ b/tests/test-page-atrules/styles.css
@@ -77,6 +77,9 @@ h2 {
 }
 
 @media screen and (min-width:480px) {
+        p {
+            background-color: whitesmoke;
+        }
     
         body{
             background-color:#6aa6cc;


### PR DESCRIPTION
Revised the CSS Usage collection script after running script on ~200k sample urls. 

Revisions made:
- Removed collection of nested rules and selectors of conditional atrules.
- Removed collection of pseudo classes of atrules.
- Cleaned up the conditional statements of atrules to contain no specific numbers.
- Simplified keyframes collected
