### PR TITLE
Adds scriptElemStats to CSSUsage.StyleWalker

### DIFF
--- a/Recipe.min.js
+++ b/Recipe.min.js
@@ -1831,11 +1831,15 @@ void function() {
     window.CSSUsage.StyleWalker.recipesToRun.push( function scriptElemStats( element, results) {
         if(element.nodeName.toLowerCase() == "script") {
             results["data"] = results["data"] || [];
+            parentElemName = element.parentNode.nodeName.toLowerCase();
             results["data"].push({
-                async       : element.hasAttribute("async"),
-                defer       : element.hasAttribute("defer"),
-                external    : element.hasAttribute("src"),
-                parentElem  : element.parentNode.nodeName.toLowerCase()
+                async       : element.hasAttribute("async") ? 1 : 0,
+                defer       : element.hasAttribute("defer") ? 1 : 0,
+                external    : element.hasAttribute("src") ? 1 : 0,
+                parentElem  : { 
+                    head    : (parentElemName === "head") ? 1 : 0,
+                    body    : (parentElemName === "body") ? 1 : 0
+                }
             });
         }
 

--- a/Recipe.min.js
+++ b/Recipe.min.js
@@ -1820,6 +1820,29 @@ void function() {
     });
 }();
 
+/* 
+    RECIPE: scriptElemStats
+    -------------------------------------------------------------
+    Author: thomasmo
+    Description: Collect stats for script elements
+*/
+
+void function() {
+    window.CSSUsage.StyleWalker.recipesToRun.push( function scriptElemStats( element, results) {
+        if(element.nodeName.toLowerCase() == "script") {
+            results["data"] = results["data"] || [];
+            results["data"].push({
+                async       : element.hasAttribute("async"),
+                defer       : element.hasAttribute("defer"),
+                external    : element.hasAttribute("src"),
+                parentElem  : element.parentNode.nodeName.toLowerCase()
+            });
+        }
+
+        return results;
+    });
+}();
+
 //
 // This file is only here to create the TSV
 // necessary to collect the data from the crawler

--- a/cssUsage.src.js
+++ b/cssUsage.src.js
@@ -1782,29 +1782,64 @@ void function() { try {
 } catch (ex) { /* do something maybe */ throw ex; } }();
 
 /* 
-    RECIPE: z-index on static flex items
+    RECIPE: Edit controls on the web
     -------------------------------------------------------------
-    Author: Francois Remy
-    Description: Get count of flex items who should create a stacking context but do not really
+    Author: Grisha Lyukshin
+    Description: Counts pages that have either input, textarea, or content editable elements
 */
 
 void function() {
+    window.CSSUsage.StyleWalker.recipesToRun.push( function editControls(/*HTML DOM Element*/ element, results) {
+        
+        // we only care about special kind of inputs
+        if(element.nodeName.toLowerCase() === "input" && 
+        	(element.getAttribute("type").toLowerCase() === "email" ||
+        	 element.getAttribute("type").toLowerCase() === "number" ||
+        	 element.getAttribute("type").toLowerCase() === "search" ||
+        	 element.getAttribute("type").toLowerCase() === "tel" ||
+        	 element.getAttribute("type").toLowerCase() === "url" ||
+        	 element.getAttribute("type").toLowerCase() === "text")) 
+        {
+            results["input"] = results["input"] || { count: 0 };
+            results["input"].count++;    
+        }
+        else if (element.nodeName.toLowerCase() === "textarea")
+        {
+			results["textarea"] = results["textarea"] || { count: 0 };
+            results["textarea"].count++;
+        }
+        else if (element.nodeName.toLowerCase() === "div" || element.nodeName.toLowerCase() === "p" || element.nodeName.toLowerCase() === "table")
+        {
+        	if(element.getAttribute("contenteditable").toLowerCase() === "true" || element.getAttribute("contenteditable").toLowerCase() === "plain-text")
+        	{
+				results["contenteditable"] = results["contenteditable"] || { count: 0 };
+            	results["contenteditable"].count++;
+        	}
+        }
+        return results;
+    });
+}();
 
-    window.CSSUsage.StyleWalker.recipesToRun.push( function zstaticflex(/*HTML DOM Element*/ element, results) {
-        if(!element.parentElement) return;
+/* 
+    RECIPE: scriptElemStats
+    -------------------------------------------------------------
+    Author: thomasmo
+    Description: Collect stats for script elements
+*/
 
-        // the problem happens if the element is a flex item with static position and non-auto z-index
-        if(getComputedStyle(element.parentElement).display != 'flex') return results;
-        if(getComputedStyle(element).position != 'static') return results;
-        if(getComputedStyle(element).zIndex != 'auto') {
-            results.likely = 1;
+void function() {
+    window.CSSUsage.StyleWalker.recipesToRun.push( function scriptElemStats( element, results) {
+        if(element.nodeName.toLowerCase() == "script") {
+            results["data"] = results["data"] || [];
+            results["data"].push({
+                async       : element.hasAttribute("async"),
+                defer       : element.hasAttribute("defer"),
+                external    : element.hasAttribute("src"),
+                parentElem  : element.parentNode.nodeName.toLowerCase()
+            });
         }
 
-        // the problem might happen if z-index could ever be non-auto
-        if(element.CSSUsage["z-index"] && element.CSSUsage["z-index"].valuesArray.length > 0) {
-            results.possible = 1;
-        }
-
+        return results;
     });
 }();
 

--- a/cssUsage.src.js
+++ b/cssUsage.src.js
@@ -1831,11 +1831,15 @@ void function() {
     window.CSSUsage.StyleWalker.recipesToRun.push( function scriptElemStats( element, results) {
         if(element.nodeName.toLowerCase() == "script") {
             results["data"] = results["data"] || [];
+            parentElemName = element.parentNode.nodeName.toLowerCase();
             results["data"].push({
-                async       : element.hasAttribute("async"),
-                defer       : element.hasAttribute("defer"),
-                external    : element.hasAttribute("src"),
-                parentElem  : element.parentNode.nodeName.toLowerCase()
+                async       : element.hasAttribute("async") ? 1 : 0,
+                defer       : element.hasAttribute("defer") ? 1 : 0,
+                external    : element.hasAttribute("src") ? 1 : 0,
+                parentElem  : { 
+                    head    : (parentElemName === "head") ? 1 : 0,
+                    body    : (parentElemName === "body") ? 1 : 0
+                }
             });
         }
 

--- a/src/recipes/scriptelem.js
+++ b/src/recipes/scriptelem.js
@@ -9,11 +9,15 @@ void function() {
     window.CSSUsage.StyleWalker.recipesToRun.push( function scriptElemStats( element, results) {
         if(element.nodeName.toLowerCase() == "script") {
             results["data"] = results["data"] || [];
+            parentElemName = element.parentNode.nodeName.toLowerCase();
             results["data"].push({
-                async       : element.hasAttribute("async"),
-                defer       : element.hasAttribute("defer"),
-                external    : element.hasAttribute("src"),
-                parentElem  : element.parentNode.nodeName.toLowerCase()
+                async       : element.hasAttribute("async") ? 1 : 0,
+                defer       : element.hasAttribute("defer") ? 1 : 0,
+                external    : element.hasAttribute("src") ? 1 : 0,
+                parentElem  : { 
+                    head    : (parentElemName === "head") ? 1 : 0,
+                    body    : (parentElemName === "body") ? 1 : 0
+                }
             });
         }
 

--- a/src/recipes/scriptelem.js
+++ b/src/recipes/scriptelem.js
@@ -1,0 +1,22 @@
+/* 
+    RECIPE: scriptElemStats
+    -------------------------------------------------------------
+    Author: thomasmo
+    Description: Collect stats for script elements
+*/
+
+void function() {
+    window.CSSUsage.StyleWalker.recipesToRun.push( function scriptElemStats( element, results) {
+        if(element.nodeName.toLowerCase() == "script") {
+            results["data"] = results["data"] || [];
+            results["data"].push({
+                async       : element.hasAttribute("async"),
+                defer       : element.hasAttribute("defer"),
+                external    : element.hasAttribute("src"),
+                parentElem  : element.parentNode.nodeName.toLowerCase()
+            });
+        }
+
+        return results;
+    });
+}();

--- a/tests/recipes/scriptElemTest.html
+++ b/tests/recipes/scriptElemTest.html
@@ -1,0 +1,27 @@
+<html>
+<head>
+    <style>
+        /* window.CSSUsage.StyleWalker requires the document to have a stylesheet to be used */
+        body { background: lightgreen; white-space:pre;}
+    </style>
+    <script src="../../../Recipe.min.js"></script>
+    <script id="inline1">
+        // this is inline script
+    </script>
+    <script id="external1"          src="https://ajax.aspnetcdn.com/ajax/jquery/jquery-1.9.0.js"></script>
+    <script id="async1"     async   src="foo2.js"></script>
+    <script id="defer1"     defer   src="foo3.js"></script>
+</head>
+<body>
+Tests scriptElemStats
+
+To see results in F12 easily, paste
+    window.RecipeResults.scriptElemStats.data)
+    <script id="inline2">
+        // this is inline script
+    </script>
+    <script id="external2"          src="foo4.js"></script>
+    <script id="async2"     async   src="foo5.js"></script>
+    <script id="defer2"     defer   src="foo6.js"></script>
+</body>
+</html>


### PR DESCRIPTION
This recipe allows for statistics to be capture for all script elements on a page, specifically
- whether the script is inline or internal
- if it has the async or defer attribute
- it's parent element (typically, head or body)